### PR TITLE
not doing XHR if no value has been provided

### DIFF
--- a/header/personal-menu.html
+++ b/header/personal-menu.html
@@ -81,7 +81,7 @@
 			displayName: {
 				type: String,
 				//to do: value is temporary until API is available in LMS
-				value: 'D2l Support'
+				value: 'D2L Support'
 			},
 			//to do: entire property is temporary until API is available in LMS
 			thumbnailUrl: {
@@ -99,7 +99,9 @@
 		},
 		_load: function() {
 			this._setThumbnail(this.thumbnailUrl); // to do: temporary until API is available
-
+			if (!this.userHref) {
+				return;
+			}
 			document.createElement('iron-request')
 				.send({url: this.userHref, handleAs: 'json'})
 				.then(function(res) {


### PR DESCRIPTION
@capajon: I was getting 404s when I used this from the LMS -- since it's not passing any value yet for `user-href`. We can revisit how/if we want to handle this once the API is ready.