### PR TITLE
personal menu margin fix

### DIFF
--- a/header/personal-menu.html
+++ b/header/personal-menu.html
@@ -25,7 +25,6 @@
 		-ms-flex: 0 0 auto;
 		-webkit-flex: 0 0 auto;
 		flex: 0 0 auto;
-		margin-right: 10px;
 		height: 42px;
 		width: 42px;
 	}
@@ -33,6 +32,7 @@
 		-ms-flex: 0 1 auto;
 		-webkit-flex: 0 1 auto;
 		flex: 0 1 auto;
+		margin-left: 10px;
 		max-width: 200px;
 		min-width: 40px;
 		overflow: hidden;


### PR DESCRIPTION
Putting the margin between the personal menu thumbnail and text back on the text. This is so that when the text gets hidden responsively at its breakpoint, the margin goes away too.

@capajon: I think it was originally this way (the RTL rule to flip it is still there), was there a reason you moved it from the text to the icon?