### PR TITLE
Fix for popup links not showing in groups

### DIFF
--- a/item-group.html
+++ b/item-group.html
@@ -108,7 +108,10 @@
 
 			if(item.entities.length > 0) {
 				item.entities.forEach(function(entity) {
-					if(entity.class.indexOf('link') > -1) {
+					if(
+						(entity.class.indexOf('link') > -1) ||
+						(entity.class.indexOf('popup') > -1)
+					) {
 						links.push(entity);
 					}
 				});


### PR DESCRIPTION
@dlockhart 
Yar, I missed checking for popup links here.  Everything else worked well though because it just reuses the behaviors.  

Do you think these are the item classes I should be checking for?  Or should I just check for the item class? I suspect that is actually the case but I'm not sure.