### PR TITLE
Us74367 menu item links

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "d2l-ajax": "^2.0.0",
     "d2l-colors": "~2.0.0",
     "d2l-dropdown": "~0.3.4",
-    "d2l-icons": "~2.4.0",
+    "d2l-icons": "^2.4.0",
     "d2l-offscreen": "~2.1.0",
     "d2l-page-load-progress": "~1.0.0",
     "polymer": "Polymer/polymer#^1.5.0",

--- a/item-group.html
+++ b/item-group.html
@@ -20,7 +20,7 @@
 		}
 	</style>
 	<template>
-		<button is="d2l-navigation-group" on-tap="_handleOpenerTap">[[groupText]]</button>
+		<button is="d2l-navigation-group" on-click="_handleOpenerClick">[[groupText]]</button>
 		<d2l-dropdown-menu class="d2l-navigation-item-group-menu">
 			<d2l-menu>
 				<template is="dom-repeat" items="{{links}}">
@@ -85,7 +85,7 @@
 			}
 			return links;
 		},
-		_handleOpenerTap: function() {
+		_handleOpenerClick: function() {
 			var opener = this.$$('button');
 			var menu = this.$$('.d2l-navigation-item-group-menu');
 			menu.open(opener);

--- a/item-group.html
+++ b/item-group.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="../d2l-dropdown/d2l-menu.html">
 <link rel="import" href="../d2l-dropdown/d2l-menu-item.html">
+<link rel="import" href="../d2l-dropdown/d2l-menu-item-link.html">
 <link rel="import" href="../d2l-icons/tier1-icons.html">
 <link rel="import" href="shared-styles.html">
 <link rel="import" href="item-link-behavior.html">
@@ -23,7 +24,17 @@
 		<d2l-dropdown-menu class="d2l-navigation-item-group-menu">
 			<d2l-menu>
 				<template is="dom-repeat" items="{{links}}">
-					<d2l-menu-item text="{{getItemLinkText(item)}}" data-index$="{{index}}"></d2l-menu-item>
+					<template is="dom-if" if="{{isRegular(item)}}">
+						<d2l-menu-item-link
+							text="[[getText(item)]]"
+							href="[[getHref(item)]]"></d2l-menu-item-link>
+					</template>
+					<template is="dom-if" if="{{!isRegular(item)}}">
+						<d2l-menu-item
+							text="[[getText(item)]]"
+							item="[[item]]"
+							on-select="_handleItemSelect"></d2l-menu-item>
+					</template>
 				</template>
 			</d2l-menu>
 		</d2l-dropdown-menu>
@@ -46,9 +57,6 @@
 		},
 		hostAttributes: {
 			role: 'listitem'
-		},
-		listeners: {
-			select: '_handleLinkSelect'
 		},
 		focus: function() {
 			this.$$('button').focus();
@@ -82,9 +90,8 @@
 			var menu = this.$$('.d2l-navigation-item-group-menu');
 			menu.open(opener);
 		},
-		_handleLinkSelect: function(e) {
-			var index = Polymer.dom(e).rootTarget.getAttribute('data-index');
-			this.onItemLinkClick(this.links[index], true);
+		_handleItemSelect: function(e) {
+			this.onPopupOrActionClick(e.target.item);
 		}
 	});
 </script>

--- a/item-link-behavior.html
+++ b/item-link-behavior.html
@@ -47,7 +47,7 @@
 			return (item.class.indexOf('action') > -1);
 		},
 		isPopupOrAction: function(item) {
-			return(this.isAction(item) || this.isPopup(item));
+			return (this.isAction(item) || this.isPopup(item));
 		},
 		isRegular: function(item) {
 			return (!this.isGroup(item) && !this.isPopupOrAction(item));

--- a/item-link-behavior.html
+++ b/item-link-behavior.html
@@ -5,7 +5,7 @@
 
 /** @polymerBehavior D2L.PolymerBehaviors.Navigation.ItemLinkBehavior */
 	var ItemLinkBehavior = {
-		getItemLinkHref: function(item) {
+		getHref: function(item) {
 			var href = undefined;
 			if (item.class.indexOf('item') > -1) {
 				if (item.class.indexOf('link') > -1) {
@@ -18,40 +18,49 @@
 			}
 			return href;
 		},
-		getItemLinkText: function(item) {
+		getText: function(item) {
 			if (item.class.indexOf('item') > -1) {
 				return item.properties.text;
 			} else if (item.class.indexOf('action') > -1) {
 				return item.title;
 			}
 		},
-		isItemGroup: function(item) {
+		isNavItem: function(item) {
+			return (
+				item &&
+				item.class &&
+				(item.class.indexOf('item') > -1) &&
+				!this.isGroup(item)
+			);
+		},
+		isGroup: function(item) {
 			return (
 				item &&
 				item.class &&
 				(item.class.indexOf('group') > -1)
 			);
 		},
-		isItemLink: function(item) {
-			return (
-				item &&
-				item.class &&
-				(item.class.indexOf('item') > -1) &&
-				!this.isItemGroup(item)
-			);
+		isPopup: function(item) {
+			return (item.class.indexOf('popup') > -1);
 		},
-		onItemLinkClick: function(item, handleRegularLink) {
-			if (item.class.indexOf('popup') > -1) {
+		isAction: function(item) {
+			return (item.class.indexOf('action') > -1);
+		},
+		isPopupOrAction: function(item) {
+			return(this.isAction(item) || this.isPopup(item));
+		},
+		isRegular: function(item) {
+			return (!this.isGroup(item) && !this.isPopupOrAction(item));
+		},
+		onPopupOrActionClick: function(item) {
+			if (this.isPopup(item)) {
 				this._onClickPopup(item);
-			} else if (item.class.indexOf('action') > -1) {
+			} else if (this.isAction(item)) {
 				this._onClickAction(item);
-			} else if (handleRegularLink) {
-				this._onClickRegular(item);
 			}
-			return false;
+			return true;
 		},
 		_onClickPopup: function(item) {
-
 			var features = '';
 			if ( item.properties.Width > 0 ) {
 				features += 'width=' + item.properties.Width + ',';
@@ -84,7 +93,6 @@
 
 		},
 		_onClickAction: function(item) {
-
 			var frm = document.createElement('form');
 			frm.setAttribute('target', '_top');
 			frm.setAttribute('action', item.href);

--- a/item-link.html
+++ b/item-link.html
@@ -26,11 +26,11 @@
 			item: Object,
 			href: {
 				type: String,
-				computed: 'getItemLinkHref(item)'
+				computed: 'getHref(item)'
 			},
 			text: {
 				type: String,
-				computed: 'getItemLinkText(item)'
+				computed: 'getText(item)'
 			}
 		},
 		hostAttributes: {
@@ -43,7 +43,7 @@
 			return (document.activeElement === this.$$('a'));
 		},
 		_handleTap: function() {
-			this.onItemLinkClick(this.item);
+			this.onPopupOrActionClick(this.item);
 		}
 	});
 </script>

--- a/mobile/menu.html
+++ b/mobile/menu.html
@@ -43,19 +43,39 @@
 				</div>
 				<d2l-menu no-side-borders style="width:100%;" label="{{localize('menu')}}">
 					<template is="dom-repeat" items="{{items}}">
-						<d2l-menu-item text="{{getItemLinkText(item)}}" item="{{item}}">
-							<template is="dom-if" if="{{isItemGroup(item)}}">
-								<d2l-menu label="{{getItemLinkText(item)}}">
+						<template is="dom-if" if="{{isRegular(item)}}">
+							<d2l-menu-item-link
+								text="[[getText(item)]]"
+								href="[[getHref(item)]]"></d2l-menu-item-link>
+						</template>
+						<template is="dom-if" if="{{isGroup(item)}}">
+							<d2l-menu-item text="[[getText(item)]]">
+								<d2l-menu>
 									<template is="dom-repeat" items="{{item.entities}}">
-										<template is="dom-if" if="{{isItemLink(item)}}">
-											<d2l-menu-item
-												text="{{getItemLinkText(item)}}"
-												item="{{item}}"></d2l-menu-item>
+										<template is="dom-if" if="{{isNavItem(item)}}">
+											<template is="dom-if" if="{{isRegular(item)}}">
+												<d2l-menu-item-link
+													text="[[getText(item)]]"
+													href="[[getHref(item)]]"></d2l-menu-item-link>
+											</template>
+											<template is="dom-if" if="{{isPopupOrAction(item)}}">
+												<d2l-menu-item
+													text="[[getText(item)]]"
+													item="[[item]]"
+													on-select="_handleSelect"></d2l-menu-item>
+											</template>
 										</template>
 									</template>
 								</d2l-menu>
-							</template>
-						</d2l-menu-item>
+							</d2l-menu-item>
+						</template>
+						<template is="dom-if" if="{{isPopupOrAction(item)}}">
+							<d2l-menu-item
+								text="[[getText(item)]]"
+								class="d2l-navigation-more-group-item"
+								item="[[item]]"
+								on-select="_handleSelect"></d2l-menu-item>
+						</template>
 					</template>
 				</d2l-menu>
 			</div>
@@ -85,7 +105,6 @@
 		],
 		listeners: {
 			'd2l-navigation-close-menu': 'close',
-			'select': '_handleSelect',
 			'hide-start': '_handleHideOrShow',
 			'show-start': '_handleHideOrShow'
 		},
@@ -102,8 +121,8 @@
 		},
 		_handleSelect: function(event) {
 			var item = Polymer.dom(event).rootTarget.item;
-			if (this.isItemLink(item)) {
-				this.onItemLinkClick(item, true);
+			if (this.isNavItem(item)) {
+				this.onPopupOrActionClick(item);
 			}
 		},
 		_handleHideOrShow: function() {

--- a/more-group.html
+++ b/more-group.html
@@ -30,22 +30,42 @@
 		<d2l-dropdown-menu>
 			<d2l-menu>
 				<template is="dom-repeat" items="{{items}}">
-					<d2l-menu-item
-						text="{{getItemLinkText(item)}}"
-						item="{{item}}"
-						class="d2l-navigation-more-group-first-level">
-						<template is="dom-if" if="{{isItemGroup(item)}}">
-							<d2l-menu label="{{getItemLinkText(item)}}">
+					<template is="dom-if" if="{{isRegular(item)}}">
+						<d2l-menu-item-link
+							text="[[getText(item)]]"
+							href="[[getHref(item)]]"
+							class="d2l-navigation-more-group-item"></d2l-menu-item-link>
+					</template>
+					<template is="dom-if" if="{{isGroup(item)}}">
+						<d2l-menu-item
+							text="[[getText(item)]]"
+							class="d2l-navigation-more-group-item">
+							<d2l-menu>
 								<template is="dom-repeat" items="{{item.entities}}">
-									<template is="dom-if" if="{{isItemLink(item)}}">
-										<d2l-menu-item
-											text="[[getItemLinkText(item)]]"
-											item="[[item]]"></d2l-menu-item>
+									<template is="dom-if" if="{{isNavItem(item)}}">
+										<template is="dom-if" if="{{isRegular(item)}}">
+											<d2l-menu-item-link
+												text="[[getText(item)]]"
+												href="[[getHref(item)]]"></d2l-menu-item-link>
+										</template>
+										<template is="dom-if" if="{{isPopupOrAction(item)}}">
+											<d2l-menu-item
+												text="[[getText(item)]]"
+												item="[[item]]"
+												on-select="_handleSelect"></d2l-menu-item>
+										</template>
 									</template>
 								</template>
 							</d2l-menu>
-						</template>
-					</d2l-menu-item>
+						</d2l-menu-item>
+					</template>
+					<template is="dom-if" if="{{isPopupOrAction(item)}}">
+						<d2l-menu-item
+							text="[[getText(item)]]"
+							class="d2l-navigation-more-group-item"
+							item="[[item]]"
+							on-select="_handleSelect"></d2l-menu-item>
+					</template>
 				</template>
 			</d2l-menu>
 		</d2l-dropdown-menu>
@@ -63,9 +83,6 @@
 		},
 		hostAttributes: {
 			role: 'listitem'
-		},
-		listeners: {
-			'select': '_handleSelect'
 		},
 		focus: function() {
 			this.$$('button').focus();
@@ -92,18 +109,15 @@
 			return -1;
 		},
 		_getItems: function() {
-			return Polymer.dom(this.root).querySelectorAll('d2l-menu-item.d2l-navigation-more-group-first-level');
+			return Polymer.dom(this.root).querySelectorAll('.d2l-navigation-more-group-item');
 		},
 		_handleOpenerTap: function() {
 			var opener = this.$$('button');
 			var menu = this.$$('d2l-dropdown-menu');
 			menu.open(opener);
 		},
-		_handleSelect: function(event) {
-			var item = Polymer.dom(event).rootTarget.item;
-			if (this.isItemLink(item)) {
-				this.onItemLinkClick(item, true);
-			}
+		_handleSelect: function(e) {
+			this.onPopupOrActionClick(e.target.item);
 		},
 		_hideItem: function(item, index) {
 			if (document.activeElement === item) {

--- a/more-group.html
+++ b/more-group.html
@@ -26,7 +26,7 @@
 		}
 	</style>
 	<template>
-		<button is="d2l-navigation-group" on-tap="_handleOpenerTap">{{localize('more')}}</button>
+		<button is="d2l-navigation-group" on-click="_handleOpenerClick">{{localize('more')}}</button>
 		<d2l-dropdown-menu>
 			<d2l-menu>
 				<template is="dom-repeat" items="{{items}}">
@@ -111,7 +111,7 @@
 		_getItems: function() {
 			return Polymer.dom(this.root).querySelectorAll('.d2l-navigation-more-group-item');
 		},
-		_handleOpenerTap: function() {
+		_handleOpenerClick: function() {
 			var opener = this.$$('button');
 			var menu = this.$$('d2l-dropdown-menu');
 			menu.open(opener);

--- a/navigation-main.html
+++ b/navigation-main.html
@@ -33,10 +33,10 @@
 	  <d2l-navigation-centerer>
 			<div class="d2l-navigation-main-wrapper">
 				<template is="dom-repeat" items="[[items]]" on-dom-change="_handleDomChange">
-					<template is="dom-if" if="[[isItemGroup(item)]]">
+					<template is="dom-if" if="[[isGroup(item)]]">
 						<d2l-navigation-item-group item=[[item]]></d2l-navigation-item-group>
 					</template>
-					<template is="dom-if" if="[[isItemLink(item)]]">
+					<template is="dom-if" if="[[isNavItem(item)]]">
 						<d2l-navigation-item-link item="[[item]]"></d2l-navigation-item-link>
 					</template>
 				</template>


### PR DESCRIPTION
@dbatiste  This is basically just to use the menu-item-link that you created in the d2l-dropdown repo.  It definitely looks a little messy with all the templates and there is some duplication of logic between the side menu and more drop down menu.  I experimented with creating a new component or two to possibly clean that up, but it would have then complicated d2l-dropdown components, and was only marginally cleaner IMO.

This also includes some minor function renaming and a fix for the on-tap issues on mobile.  I do need to follow up with some styling changes in d2l-dropdown separately I believe (to fix the "double border" issue, probably because of the extra templates... I know how much you love them).