### PR TITLE
Decoupling course-menu from dropdown.

### DIFF
--- a/course-menu.html
+++ b/course-menu.html
@@ -18,7 +18,7 @@
 		is: 'd2l-navigation-course-menu',
 
 		listeners: {
-			'partial-render': '_onPartialRender',
+			'partial-render': '_onPartialRender'
 		},
 
 		behaviors: [
@@ -59,7 +59,7 @@
 
 		},
 
-		_onAfterPartialRender: function(id) {
+		_onAfterPartialRender: function() {
 			if (!this.loaded) {
 				return;
 			}

--- a/course-menu.html
+++ b/course-menu.html
@@ -1,0 +1,75 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-polymer-behaviors/d2l-id.html">
+<link rel="import" href="find-page-object-behavior.html">
+<link rel="import" href="graft-behavior.html">
+
+<dom-module id="d2l-navigation-course-menu">
+	<template>
+		<style>
+			:host {
+				display: block;
+			}
+		</style>
+		<div class="d2l-navigation-course-menu-container"></div>
+	</template>
+</dom-module>
+<script>
+	Polymer({
+		is: 'd2l-navigation-course-menu',
+
+		listeners: {
+			'partial-render': '_onPartialRender',
+		},
+
+		behaviors: [
+			window.D2L.PolymerBehaviors.Navigation.FindPageObjectBehavior,
+			window.D2L.PolymerBehaviors.Navigation.GraftBehavior
+		],
+
+		properties: {
+			loaded: Boolean
+		},
+
+		ready: function() {
+			this._onAfterPartialRender = this._onAfterPartialRender.bind(this);
+		},
+
+		attached: function() {
+			var onAfterEvent = this.findPageObject('D2L.LP.Web.UI.Html.PartialRendering.OnAfter');
+			onAfterEvent.AddListener(this._onAfterPartialRender);
+		},
+
+		detached: function() {
+			var onAfterEvent = this.findPageObject('D2L.LP.Web.UI.Html.PartialRendering.OnAfter');
+			onAfterEvent.RemoveListener(this._onAfterPartialRender);
+		},
+
+		load: function() {
+
+			if (this.loaded) {
+				return;
+			}
+
+			var placeholderId = D2L.Id.getUniqueId();
+
+			this.$$('.d2l-navigation-course-menu-container')
+				.setAttribute('id', placeholderId);
+
+			this.graft(placeholderId);
+
+		},
+
+		_onAfterPartialRender: function(id) {
+			if (!this.loaded) {
+				return;
+			}
+			this.fire('d2l-navigation-course-menu-updated');
+		},
+
+		_onPartialRender: function() {
+			this.loaded = true;
+			this.fire('d2l-navigation-course-menu-loaded');
+		}
+
+	});
+</script>

--- a/course-menu.html
+++ b/course-menu.html
@@ -30,20 +30,6 @@
 			loaded: Boolean
 		},
 
-		ready: function() {
-			this._onAfterPartialRender = this._onAfterPartialRender.bind(this);
-		},
-
-		attached: function() {
-			var onAfterEvent = this.findPageObject('D2L.LP.Web.UI.Html.PartialRendering.OnAfter');
-			onAfterEvent.AddListener(this._onAfterPartialRender);
-		},
-
-		detached: function() {
-			var onAfterEvent = this.findPageObject('D2L.LP.Web.UI.Html.PartialRendering.OnAfter');
-			onAfterEvent.RemoveListener(this._onAfterPartialRender);
-		},
-
 		load: function() {
 
 			if (this.loaded) {
@@ -57,13 +43,6 @@
 
 			this.graft(placeholderId);
 
-		},
-
-		_onAfterPartialRender: function() {
-			if (!this.loaded) {
-				return;
-			}
-			this.fire('d2l-navigation-course-menu-updated');
 		},
 
 		_onPartialRender: function() {

--- a/header/actions.html
+++ b/header/actions.html
@@ -31,8 +31,7 @@
 		}
 	</style>
 	<template>
-		<d2l-navigation-header-course-menu
-			graft-location="[[courseMenuLocation]]"></d2l-navigation-header-course-menu>		
+		<d2l-navigation-header-course-menu course-menu-location="[[courseMenuLocation]]"></d2l-navigation-header-course-menu>
 		<d2l-navigation-notifications notifications="[[notifications]]"></d2l-navigation-notifications>
 		<d2l-navigation-personal-menu
 			user-href="[[userHref]]"

--- a/header/course-menu.html
+++ b/header/course-menu.html
@@ -1,20 +1,21 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../button-highlight-icon.html">
+<link rel="import" href="../course-menu.html">
 <link rel="import" href="../divider.html">
-<link rel="import" href="../graft-dropdown-behavior.html">
 <link rel="import" href="../icons.html">
 <link rel="import" href="../localize-behavior.html">
+
 <dom-module id="d2l-navigation-header-course-menu">
 	<style>
 		:host {
 			display: inline-block;
 			height: 100%;
 		}
-		button {
+ 		:host button {
 			margin: 0 5px;
 		}
-		d2l-dropdown {
+		:host d2l-dropdown {
 			min-width: 450px;
 		}
 	</style>
@@ -23,16 +24,71 @@
 			is="d2l-navigation-button-highlight-icon"
 			icon="d2l-tier3:classes"
 			text="{{localize('selectCourse')}}"></button>
-		<d2l-dropdown vertical-offset="-5" horizontal-offset="-27"></d2l-dropdown>
+		<d2l-dropdown vertical-offset="-5" horizontal-offset="-27">
+			<d2l-navigation-course-menu graft-location="[[courseMenuLocation]]"></d2l-navigation-course-menu>
+		</d2l-dropdown>
 		<d2l-navigation-divider></d2l-navigation-divider>
 	</template>
 </dom-module>
 <script>
 	Polymer({
 		is: 'd2l-navigation-header-course-menu',
+
 		behaviors: [
-			window.D2L.PolymerBehaviors.Navigation.LocalizeBehavior,
-			window.D2L.PolymerBehaviors.Navigation.GraftDropdownBehavior
-		]
+			window.D2L.PolymerBehaviors.Navigation.LocalizeBehavior
+		],
+
+		properties: {
+			courseMenuLocation: String
+		},
+
+		_dropdown: null,
+		_opener: null,
+		_menu: null,
+
+		attached: function() {
+			this._opener = this.$$('[is="d2l-navigation-button-highlight-icon"]');
+			this.listen(this._opener, 'click', '_onClick');
+
+			this._dropdown = this.$$('d2l-dropdown');
+			this.listen(this._dropdown, 'open', '_onOpen');
+			this.listen(this._dropdown, 'close', '_onClose');
+
+			this._menu = this.$$('d2l-navigation-course-menu');
+		},
+
+		detached: function() {
+			this.unlisten(this._opener, 'click', '_onClick');
+			this.unlisten(this._dropdown, 'open', '_onOpen');
+			this.unlisten(this._dropdown, 'close', '_onClose');
+		},
+
+		_onClose: function() {
+			Polymer.dom(this._opener).removeAttribute('active');
+		},
+
+		_onOpen: function() {
+			Polymer.dom(this._opener).setAttribute('active', 'active');
+		},
+
+		_onClick: function() {
+
+			if (this._menu.loaded) {
+
+				this._dropdown.open(this._opener);
+
+			} else {
+
+				var onLoad = function() {
+					this._menu.removeEventListener('d2l-navigation-course-menu-loaded', onLoad);
+					this._dropdown.open(this._opener);
+				}.bind(this);
+
+				this._menu.addEventListener('d2l-navigation-course-menu-loaded', onLoad);
+				this._menu.load();
+			}
+
+		}
+
 	});
 </script>


### PR DESCRIPTION
@dlockhart : this change decouples course-menu from d2l-dropdown which is specific to desktop rendering.  Mobile rendering will use `course-menu.html` without `d2l-dropdown`. This will further make it easier to replace the grafting logic.

Mobile course selector coming in separate separate PR.