### PR TITLE
Dbatiste/mobile mobile close

### DIFF
--- a/mobile/header.html
+++ b/mobile/header.html
@@ -1,8 +1,5 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
-<link rel="import" href="../button.html">
-<link rel="import" href="../icons.html">
-<link rel="import" href="../localize-behavior.html">
 
 <dom-module id="d2l-navigation-mobile-header">
 	<template>
@@ -14,9 +11,6 @@
 				height: var(--d2l-navigation-header-height);
 				padding: 0 1rem;
 			}
-			:host button {
-				flex: none;
-			}
 			@media(max-width: 615px) {
 				:host {
 					height: var(--d2l-navigation-header-height-mobile);
@@ -24,26 +18,10 @@
 			}
 		</style>
 		<content></content>
-		<button
-			is="d2l-navigation-button"
-			hide-text
-			has-outline
-			icon="navigation-t3:close"
-			on-tap="_handleClose">{{localize('close')}}
-		</button>
 	</template>
 </dom-module>
 <script>
 	Polymer({
-		is: 'd2l-navigation-mobile-header',
-
-		behaviors: [
-			window.D2L.PolymerBehaviors.Navigation.LocalizeBehavior
-		],
-
-		_handleClose: function() {
-			this.fire('d2l-navigation-mobile-close');
-		}
-
+		is: 'd2l-navigation-mobile-header'
 	});
 </script>

--- a/slide-out-menu.html
+++ b/slide-out-menu.html
@@ -1,12 +1,11 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../d2l-offscreen/d2l-offscreen-shared-styles.html">
 <link rel="import" href="button.html">
 <link rel="import" href="icons.html">
 <link rel="import" href="localize-behavior.html">
 
 <dom-module id="d2l-navigation-slide-out-menu">
-	<style include="d2l-colors d2l-offscreen-shared-styles">
+	<style include="d2l-colors">
 		:host {
 			display: block;
 		}
@@ -52,16 +51,15 @@
 			width: 84%;
 		}
 		.d2l-navigation-slide-out-menu-mask-close > button {
-			margin-left: calc(100% + 10px);
-			margin-top: 10px;
-			@apply(--d2l-offscreen);
+			position: relative;
+			top: 10px;
 		}
 		.d2l-navigation-slide-out-menu-mask-close > button:focus {
-			position: static !important;
-			height: auto;
-			overflow: visible;
-			white-space: normal;
-			width: auto;
+			left: calc(100% + 10px);
+		}
+		:host-context([dir="rtl"]) .d2l-navigation-slide-out-menu-mask-close > button:focus {
+			left: auto;
+			right: calc(100% + 10px);
 		}
 		:host([state='opened']) .d2l-navigation-slide-out-menu-mask {
 			height: 100vh;

--- a/slide-out-menu.html
+++ b/slide-out-menu.html
@@ -1,7 +1,12 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-offscreen/d2l-offscreen-shared-styles.html">
+<link rel="import" href="button.html">
+<link rel="import" href="icons.html">
+<link rel="import" href="localize-behavior.html">
+
 <dom-module id="d2l-navigation-slide-out-menu">
-	<style include="d2l-colors">
+	<style include="d2l-colors d2l-offscreen-shared-styles">
 		:host {
 			display: block;
 		}
@@ -42,6 +47,22 @@
 			width: 0;
 			z-index: 100;
 		}
+		.d2l-navigation-slide-out-menu-mask-close {
+			min-width: 300px;
+			width: 84%;
+		}
+		.d2l-navigation-slide-out-menu-mask-close > button {
+			margin-left: calc(100% + 10px);
+			margin-top: 10px;
+			@apply(--d2l-offscreen);
+		}
+		.d2l-navigation-slide-out-menu-mask-close > button:focus {
+			position: static !important;
+			height: auto;
+			overflow: visible;
+			white-space: normal;
+			width: auto;
+		}
 		:host([state='opened']) .d2l-navigation-slide-out-menu-mask {
 			height: 100vh;
 			opacity: 0.8;
@@ -50,23 +71,38 @@
 		}
 	</style>
 	<template>
-		<div class="d2l-navigation-slide-out-menu-mask" on-tap="close"></div>
-		<div class="d2l-navigation-slide-out-menu-content">
+		<div class="d2l-navigation-slide-out-menu-mask" on-tap="close">
 			<div
 				class="d2l-navigation-slide-out-menu-first"
 				on-focus="focusFirst"
 				tabindex="0"></div>
-			<content></content>
-			<div
-				class="d2l-navigation-slide-out-menu-last"
-				on-focus="focusLast"
-				tabindex="0"></div>
+			<div class="d2l-navigation-slide-out-menu-mask-close">
+				<button
+					is="d2l-navigation-button"
+					hide-text
+					has-outline
+					icon="navigation-t3:close"
+					on-tap="close">{{localize('close')}}
+				</button>
+			</div>
 		</div>
+		<div class="d2l-navigation-slide-out-menu-content">
+			<content></content>
+		</div>
+		<div
+			class="d2l-navigation-slide-out-menu-last"
+			on-focus="focusLast"
+			tabindex="0"></div>
 	</template>
 </dom-module>
 <script>
 	Polymer({
 		is: 'd2l-navigation-slide-out-menu',
+
+		behaviors: [
+			window.D2L.PolymerBehaviors.Navigation.LocalizeBehavior
+		],
+
 		properties: {
 			state: {
 				type: String,
@@ -79,6 +115,7 @@
 			},
 			_opener: Object
 		},
+
 		open: function(opener) {
 
 			if (this.state !== 'closed') {
@@ -95,6 +132,7 @@
 			this.async(function() { this.state = 'opened'; }.bind(this), 50);
 
 		},
+
 		close: function() {
 
 			if (this.state !== 'opened') {
@@ -113,6 +151,7 @@
 			}
 
 		},
+
 		focusFirst: function() {
 			if (this._ignoreFocus) {
 				this._ignoreFocus = false;
@@ -121,6 +160,7 @@
 			this._ignoreFocus = true;
 			this.$$('.d2l-navigation-slide-out-menu-last').focus();
 		},
+
 		focusLast: function() {
 			if (this._ignoreFocus) {
 				this._ignoreFocus = false;
@@ -129,5 +169,6 @@
 			this._ignoreFocus = true;
 			this.$$('.d2l-navigation-slide-out-menu-first').focus();
 		}
+
 	});
 </script>


### PR DESCRIPTION
This change moves the close button from the mobile header to the mobile mask/shim so that it's positioned outside the menu header.  It is hidden from view until focused (keyboard case).  Mouse users simply click/touch anywhere outside the menu.