### PR TITLE
Flip margin in mobile course menu header for RTL.

### DIFF
--- a/mobile/course-menu-header.html
+++ b/mobile/course-menu-header.html
@@ -27,6 +27,10 @@
 				text-overflow: ellipsis;
 				white-space: nowrap;
 			}
+			:host-context([dir="rtl"]) span {
+				margin-left: 62px;
+				margin-right: 0;
+			}
 			:host-context([dir="rtl"]) button {
 				transform: scaleX(-1);
 			}


### PR DESCRIPTION
This change is needed to correctly center the header text in the mobile course menu header when `dir="rtl"`.