### PR TITLE
Dbatiste/mobile menu course menu click

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "d2l-ajax": "^2.0.0",
     "d2l-colors": "~2.0.0",
-    "d2l-dropdown": "~0.3.8",
+    "d2l-dropdown": "~0.3.9",
     "d2l-hierarchical-view": "~0.0.9",
     "d2l-icons": "^2.5.0",
     "d2l-offscreen": "~2.1.0",

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "d2l-ajax": "^2.0.0",
     "d2l-colors": "~2.0.0",
-    "d2l-dropdown": "~0.3.7",
+    "d2l-dropdown": "~0.3.8",
     "d2l-hierarchical-view": "~0.0.9",
     "d2l-icons": "^2.5.0",
     "d2l-offscreen": "~2.1.0",

--- a/mobile/course-menu-header.html
+++ b/mobile/course-menu-header.html
@@ -41,7 +41,7 @@
 				hide-text
 				has-outline
 				icon="d2l-tier1:chevron-left"
-				on-tap="_handleShowNav">[[orgUnitName]]</button>
+				on-click="_handleShowNav">[[orgUnitName]]</button>
 			<span>[[orgUnitName]]</span>
 		</div>
 	</template>


### PR DESCRIPTION
@dlockhart : here's the change to address the tap issue.  It includes `d2l-dropdown@v0.3.8` to address switching from sub0menu back to root nav in mobile.  And, updates further to `d2l-dropdown@v0.3.9` that includes the latest focus/auto-close fixes.