### PR TITLE
Hide user menus

### DIFF
--- a/header/course-menu.html
+++ b/header/course-menu.html
@@ -46,7 +46,10 @@
 		],
 
 		properties: {
-			courseMenuLocation: String
+			courseMenuLocation: {
+				type: String,
+				reflectToAttribute: true
+			}
 		},
 
 		_dropdown: null,

--- a/header/course-menu.html
+++ b/header/course-menu.html
@@ -10,8 +10,11 @@
 <dom-module id="d2l-navigation-header-course-menu">
 	<style>
 		:host {
-			display: inline-block;
+			display: none;
 			height: 100%;
+		}
+		:host([course-menu-location]) {
+			display: inline-block;
 		}
  		:host button {
 			margin: 0 5px;

--- a/header/personal-menu.html
+++ b/header/personal-menu.html
@@ -11,8 +11,11 @@
 <dom-module id="d2l-navigation-personal-menu">
 	<style include="d2l-offscreen-shared-styles">
 	:host {
-		display: inline-block;
+		display: none;
 		height: 100%;
+	}
+	:host([user-href]) {
+		display: inline-block;
 	}
 	.d2l-navigation-personal-menu-wrapper {
 		-webkit-align-items: center;
@@ -85,7 +88,10 @@
 	Polymer({
 		is: 'd2l-navigation-personal-menu',
 		properties: {
-			userHref: String,
+			userHref: {
+				type: String,
+				reflectToAttribute: true
+			},
 			displayName: String
 		},
 		behaviors: [window.D2L.PolymerBehaviors.Navigation.GraftDropdownBehavior],

--- a/mobile/course-header.html
+++ b/mobile/course-header.html
@@ -26,6 +26,12 @@
 				text-overflow: ellipsis;
 				white-space: nowrap;
 			}
+			:host .d2l-navigation-mobile-course-header-menu {
+				display: none;
+			}
+			:host([has-course-menu]) .d2l-navigation-mobile-course-header-menu {
+				display: inline-block;
+			}
 			:host button {
 				height: 100%;
 			}
@@ -54,6 +60,7 @@
 			</div>
 			<button
 				is="d2l-navigation-button-highlight-icon"
+				class="d2l-navigation-mobile-course-header-menu"
 				icon="d2l-tier3:classes"
 				text="{{localize('selectCourse')}}"
 				on-tap="_handleShowCourseMenu"></button>
@@ -69,6 +76,11 @@
 		],
 
 		properties: {
+			hasCourseMenu: {
+				type: Boolean,
+				reflectToAttribute: true,
+				value: false
+			},
 			myHome: String,
 			orgUnitHome: String,
 			orgUnitName: String

--- a/mobile/menu.html
+++ b/mobile/menu.html
@@ -56,11 +56,13 @@
 				<div class="d2l-navigation-mobile-header-wrapper">
 					<d2l-navigation-mobile-header>
 						<d2l-navigation-mobile-org-header
+							has-course-menu="[[hasCourseMenu]]"
 							logo="[[logo]]"
 							logo-href="[[logoHref]]"
 							logo-text="[[logoText]]">
 						</d2l-navigation-mobile-org-header>
 						<d2l-navigation-mobile-course-header
+							has-course-menu="[[hasCourseMenu]]"
 							my-home="[[myHome]]"
 							org-unit-name="[[orgUnitName]]"
 							org-unit-home="[[orgUnitHome]]">
@@ -96,6 +98,10 @@
 				observer: '_handleBandColorChange'
 			},
 			courseMenuLocation: String,
+			hasCourseMenu: {
+				type: Boolean,
+				computed: '_hasCourseMenu(courseMenuLocation)'
+			},
 			items: {
 				type: Array,
 				observer: '_itemsChanged'
@@ -138,6 +144,10 @@
 			this._handleLoadCourseMenu();
 		},
 
+		_hasCourseMenu: function(courseMenuLocation) {
+			return courseMenuLocation !== undefined;
+		},
+
 		_handleShowCourseNav: function() {
 			this.header = 'nav';
 			this.$$('d2l-menu').show();
@@ -153,7 +163,7 @@
 			this.$$('d2l-navigation-mobile-course-menu-header').focus();
 
 			var courseMenu = this.$$('d2l-navigation-course-menu');
-			if (courseMenu.loaded) {
+			if (this.courseMenuLocation === undefined || courseMenu.loaded) {
 				return;
 			}
 

--- a/mobile/org-header.html
+++ b/mobile/org-header.html
@@ -26,6 +26,12 @@
 				flex: none;
 				height: 100%;
 			}
+			:host .d2l-navigation-mobile-org-header-course-menu {
+				display: none;
+			}
+			:host([has-course-menu]) .d2l-navigation-mobile-org-header-course-menu {
+				display: inline-block;
+			}
 		</style>
 		<div class="d2l-navigation-mobile-org-header-container">
 			<d2l-navigation-logo
@@ -35,6 +41,7 @@
 			</d2l-navigation-logo>
 			<button
 				is="d2l-navigation-button-highlight-icon"
+				class="d2l-navigation-mobile-org-header-course-menu"
 				icon="d2l-tier3:classes"
 				text="{{localize('selectCourse')}}"
 				on-tap="_handleShowCourseMenu"></button>
@@ -50,6 +57,11 @@
 		],
 
 		properties: {
+			hasCourseMenu: {
+				type: Boolean,
+				reflectToAttribute: true,
+				value: false
+			},
 			logo: String,
 			logoHref: String,
 			logoText: String

--- a/navigation.html
+++ b/navigation.html
@@ -157,7 +157,9 @@
 				var newItems = [];
 				res.entities.forEach(function(e) {
 					if (e.class.indexOf('admin') > -1) {
-						this.hasAdminMenu = true;
+						if (this.adminMenuLocation !== undefined) {
+							this.hasAdminMenu = true;
+						}
 					} else if (e.class.indexOf('item') > -1) {
 						newItems.push(e);
 					}

--- a/test/header/personal-menu.html
+++ b/test/header/personal-menu.html
@@ -189,8 +189,8 @@
 				});
 
 				it('should not be hidden', function() {
-					var offsetParentIsNull = (menu.offsetParent === null);
-					expect(offsetParentIsNull).to.be.false;
+					var style  = window.getComputedStyle(menu);
+					expect(style.display).to.be.eql('inline-block');
 				});
 
 				it('should set "displayName" property', function() {
@@ -272,8 +272,8 @@
 				});
 
 				it('should be hidden', function() {
-					var offsetParentIsNull = (menu.offsetParent === null);
-					expect(offsetParentIsNull).to.be.true;
+					var style  = window.getComputedStyle(menu);
+					expect(style.display).to.eql('none');
 				});
 
 			});

--- a/test/header/personal-menu.html
+++ b/test/header/personal-menu.html
@@ -16,6 +16,12 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="no-data-attribute">
+			<template>
+				<d2l-navigation-personal-menu></d2l-navigation-personal-menu>
+			</template>
+		</test-fixture>
+
 		<test-fixture id="display-name">
 			<template>
 				<d2l-navigation-personal-menu user-href="display-name.json"></d2l-navigation-personal-menu>
@@ -182,6 +188,11 @@
 					return setupMenu('display-name');
 				});
 
+				it('should not be hidden', function() {
+					var offsetParentIsNull = (menu.offsetParent === null);
+					expect(offsetParentIsNull).to.be.false;
+				});
+
 				it('should set "displayName" property', function() {
 					expect(menu.displayName).to.eql('Jim Smith');
 				});
@@ -250,6 +261,19 @@
 				it('should just render nothing', function() {
 					var elem = menu.$$('.d2l-navigation-personal-menu-text');
 					expect(elem.innerText.trim()).to.eql('');
+				});
+
+			});
+
+			describe('no user-href attribute', function() {
+
+				beforeEach(function() {
+					menu = fixture('no-data-attribute');
+				});
+
+				it('should be hidden', function() {
+					var offsetParentIsNull = (menu.offsetParent === null);
+					expect(offsetParentIsNull).to.be.true;
 				});
 
 			});

--- a/test/navigation.html
+++ b/test/navigation.html
@@ -28,7 +28,13 @@
 			</template>
 		</test-fixture>
 
-		<test-fixture id="admin-items">
+		<test-fixture id="admin-items-with-menu">
+			<template>
+				<d2l-navigation href="admin-items.json" admin-menu-location="foo"></d2l-navigation>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="admin-items-without-menu">
 			<template>
 				<d2l-navigation href="admin-items.json"></d2l-navigation>
 			</template>
@@ -255,14 +261,26 @@
 
 			});
 
-			describe('admin items', function() {
+			describe('admin items with menu location', function() {
 
 				beforeEach(function() {
-					return setupNav('admin-items');
+					return setupNav('admin-items-with-menu');
 				});
 
 				it('should have admin menu', function() {
 					expect(navigation.hasAdminMenu).to.be.true;
+				});
+
+			});
+
+			describe('admin items without menu location', function() {
+
+				beforeEach(function() {
+					return setupNav('admin-items-without-menu');
+				});
+
+				it('should not have admin menu', function() {
+					expect(navigation.hasAdminMenu).to.be.false;
 				});
 
 			});


### PR DESCRIPTION
@dbatiste @capajon look OK? This is the first step towards handling the case where navigation is getting rendered on pages where the user isn't logged in. So we don't want pretty much any of the menus (admin, course, notification, personal, etc.).

Eventually this will get cleaner as the APIs will support anonymous requests and we'll more just be using the data that does/doesn't come back from them.