### PR TITLE
Adjusting z-index of mobile menu to be much greater

### DIFF
--- a/slide-out-menu.html
+++ b/slide-out-menu.html
@@ -21,7 +21,7 @@
 			transform: translateX(-100%);
 			transition: transform 300ms;
 			width: 84%;
-			z-index: 200;
+			z-index: 9000;
 		}
 		:host-context([dir='rtl']) .d2l-navigation-slide-out-menu-content {
 			right: 0;
@@ -44,7 +44,7 @@
 			transition: opacity 300ms, width 0s 0.3s, height 0s 0.3s;
 			top: 0;
 			width: 0;
-			z-index: 100;
+			z-index: 8999;
 		}
 		.d2l-navigation-slide-out-menu-mask-close {
 			min-width: 300px;


### PR DESCRIPTION
@dlockhart z-indexes... ughhh.

Here's some I found in the LMS for reference
Flating buttons - 999 (this is the one I wanted to make sure the menu is above)
Dialogs - 1002
Dropdown - 1000
Confirmation alerts - 10000

I did some searching on github too.  There are a lot of z-indexes in our FRAs, most seem < 9000 and greater than 500 or so.  Not sure which are nested of course.

Anyway, 9000 seemed right to me.  We want alerts to be highest 'priority' I believe, but otherwise the mobile menu should probably win out against almost everything else... I think.

And over 9000? Seems right out.
![image](https://cloud.githubusercontent.com/assets/5125171/18677937/7ad5096c-7f28-11e6-9fc9-c8a4e8c0cea0.png)

Floating buttons might need to be adjusted too, to be lower, but there is no grievous scenario I am aware of right now so I'll just leave it alone.