### PR TITLE
Dbatiste/mobile admin tools

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "d2l-colors": "^2.1.0",
     "d2l-dropdown": "~2.2.2",
     "d2l-hierarchical-view": "~0.0.10",
-    "d2l-icons": "^2.8.3",
+    "d2l-icons": "^2.9.3",
     "d2l-menu": "~0.0.5",
     "d2l-offscreen": "^2.1.0",
     "d2l-page-load-progress": "^1.1.1",

--- a/mobile/menu.html
+++ b/mobile/menu.html
@@ -150,7 +150,7 @@
 		_adminItemsChanged: function() {
 
 			var itemsData = this.adminItems;
-			if (!itemsData || itemsData.length === 0 || !itemsData[0].entities || itemsData[0].entities.length === 0) {
+			if (!itemsData || itemsData.length === 0) {
 				return;
 			}
 
@@ -161,9 +161,11 @@
 			var toolsMenu = document.createElement('d2l-menu');
 			Polymer.dom(toolsItem).appendChild(toolsMenu);
 
-			itemsData = itemsData[0].entities;
 			var toolsMenuApi = Polymer.dom(toolsMenu);
 			itemsData.forEach(function(itemData) {
+				if (!itemData.entities || itemData.entities.length === 0) {
+					return;
+				}
 				var item = this.createMenuItem(itemData);
 				if (item) {
 					toolsMenuApi.appendChild(item);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "postinstall": "bower install",
     "test": "npm run test:lint:js && npm run test:lint:wc && wct --skip-plugin sauce",
     "test:lint:js": "eslint *.html header/*.html mobile/*.html samples/*.html test/*.html test/**/*.html",
-    "test:lint:wc": "polylint"
+    "test:lint:wc": "polylint --no-recursion"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@dlockhart : this is the change to fix the mobile admin tools menu

* updates rendering for admin tools links (no longer a root admin entity)
* updates polylint task to include --no-recursion flag so iron-icon errors are ignored