### PR TITLE
Add behavior for suppressing nav elements

### DIFF
--- a/navigation.html
+++ b/navigation.html
@@ -3,13 +3,14 @@
 <link rel="import" href="../d2l-page-load-progress/d2l-page-load-progress.html">
 <link rel="import" href="navigation-resolved.html">
 <link rel="import" href="no-duplicate-behavior.html">
+<link rel="import" href="suppress-nav-behavior.html">
 <dom-module id="d2l-navigation">
 	<style>
 		:host {
 			display: block;
 			min-width: 320px;
 		}
-		:host([duplicate]) {
+		:host([suppressed]) {
 			display: none;
 		}
 		d2l-navigation-resolved {
@@ -56,7 +57,8 @@
 	Polymer({
 		is: 'd2l-navigation',
 		behaviors: [
-			window.D2L.PolymerBehaviors.Navigation.NoDuplicateBehavior
+			window.D2L.PolymerBehaviors.Navigation.NoDuplicateBehavior,
+			window.D2L.PolymerBehaviors.Navigation.SuppressNavBehavior
 		],
 		properties: {
 			adminMenuLocation: String,
@@ -69,7 +71,7 @@
 				type: Number,
 				value: 200
 			},
-			duplicate: {
+			suppressed: {
 				reflectToAttribute: true,
 				type: Boolean,
 				value: false
@@ -113,9 +115,9 @@
 			userHref: String
 		},
 		ready: function() {
-			var val = this.isDuplicate();
+			var val = this.isSuppressed() || this.isDuplicate();
 			if (val) {
-				this.setAttribute('duplicate', 'duplicate');
+				this.setAttribute('suppressed', 'suppressed');
 				this.loadState = 'ready';
 			} else {
 				this.$.navRequest.url = this.href;

--- a/suppress-nav-behavior.html
+++ b/suppress-nav-behavior.html
@@ -1,0 +1,37 @@
+<link rel="import" href="../polymer/polymer.html">
+<script>
+(function() {
+	'use strict';
+
+	/** @polymerBehavior D2L.PolymerBehaviors.Navigation.SuppressNavBehavior */
+	var SuppressNavBehavior = {
+		isSuppressed: function() {
+			if (window.parent === window) {
+				return false;
+			}
+			try {
+				var win = window;
+				while (win !== win.parent) {
+					win = win.parent;
+					var elems = win.document.getElementsByClassName('d2l-suppress-nav');
+					if (elems.length > 0) {
+						return true;
+					}
+					if (win === win.parent) {
+						break;
+					}
+				}
+			} catch (e) {
+				// cross-domain issue, we can fix possibly using postMessage
+			}
+			return false;
+		}
+	};
+
+	window.D2L = window.D2L || {};
+	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+	window.D2L.PolymerBehaviors.Navigation = window.D2L.PolymerBehaviors.Navigation || {};
+	/** @polymerBehavior */
+	window.D2L.PolymerBehaviors.Navigation.SuppressNavBehavior = [SuppressNavBehavior];
+})();
+</script>

--- a/test/test-elements.html
+++ b/test/test-elements.html
@@ -1,6 +1,5 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../localize-behavior.html">
-<link rel="import" href="../no-duplicate-behavior.html">
 <script>
 	Polymer({
 		is: 'test-localize',


### PR DESCRIPTION
The [React Valence UI IFrame](https://github.com/Brightspace/react-valence-ui-iframe) control used by the [Activity Sequence Viewer](https://github.com/Brightspace/sequence-viewer) was relying on being able to use a hidden `d2l-navigation` element to cause child navigation elements to consider themselves duplicates and therefore refrain from having any navigation on the pages. #180 removed that 'unsupported feature' so the idea of this PR is to introduce a mechanism for triggering `d2l-navigation` elements to suppress themselves.