### PR TITLE
upgrading to d2l-ajax 2.0.1, which contains fix for IE treating no UR…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "/samples/"
   ],
   "dependencies": {
-    "d2l-ajax": "^2.0.0",
+    "d2l-ajax": "^2.0.1",
     "d2l-colors": "^2.1.0",
     "d2l-dropdown": "~2.2.2",
     "d2l-hierarchical-view": "~0.0.10",


### PR DESCRIPTION
…Ls as relative