### PR TITLE
Hoping to fix More chomper sometimes not working either in Chrome in …

### DIFF
--- a/navigation-main.html
+++ b/navigation-main.html
@@ -106,11 +106,8 @@
 
 			this._showMainGroup();
 			var index = navItemsLength - 1;
-			if (index < 0) {
-				return; // shouldn't happen but being sure
-			}
 
-			while (!this._isOnFirstRow(this._moreGroup)) {
+			while ((index >= 0) && (!this._isOnFirstRow(this._moreGroup))) {
 				this._hideItem(navItems[index]);
 				index--;
 			}

--- a/navigation-main.html
+++ b/navigation-main.html
@@ -87,7 +87,7 @@
 
 			Polymer.dom(this).node.removeAttribute('justify-content');
 
-			if (navItemsLength === 0) {
+			if (!navItemsLength) {
 				this._hideMainGroup();
 				return;
 			}
@@ -106,6 +106,10 @@
 
 			this._showMainGroup();
 			var index = navItemsLength - 1;
+			if (index < 0) {
+				return; // shouldn't happen but being sure
+			}
+
 			while (!this._isOnFirstRow(this._moreGroup)) {
 				this._hideItem(navItems[index]);
 				index--;

--- a/navigation-main.html
+++ b/navigation-main.html
@@ -141,17 +141,18 @@
 			Polymer.dom(navItem).node.style.display = 'none';
 		},
 		_handleDomChange: function() {
-			this.async(function() {
-				this._navItems = Polymer.dom(this.root).querySelectorAll(
-					'd2l-navigation-item-link,d2l-navigation-item-group'
-				);
-				if (this._navItems.length > 0) {
-					var me = this;
-					setTimeout(function() {
-						me._chomp();
-					}, 20); // Firefox seems to need a few extra ms
-				}
-			});
+			if (this.items.length) {
+				this.async(function() {
+					this._navItems = Polymer.dom(this.root).querySelectorAll(
+						'd2l-navigation-item-link,d2l-navigation-item-group'
+					);
+					if (this._navItems.length > 0) {
+						setTimeout(function() {
+							this._chomp();
+						}.bind(this), 100); // hackily ensuring DOM is ready to determine row positions
+					}
+				});
+			}
 		},
 		_handleMoreGroupFocusedItemHidden: function(event, details) {
 			this._focusItem(details.index);

--- a/navigation-main.html
+++ b/navigation-main.html
@@ -145,18 +145,19 @@
 			Polymer.dom(navItem).node.style.display = 'none';
 		},
 		_handleDomChange: function() {
-			if (this.items.length) {
-				this.async(function() {
-					this._navItems = Polymer.dom(this.root).querySelectorAll(
-						'd2l-navigation-item-link,d2l-navigation-item-group'
-					);
-					if (this._navItems.length > 0) {
-						setTimeout(function() {
-							this._chomp();
-						}.bind(this), 100); // hackily ensuring DOM is ready to determine row positions
-					}
-				});
+			if (!this.items.length) {
+				return;
 			}
+			this.async(function() {
+				this._navItems = Polymer.dom(this.root).querySelectorAll(
+					'd2l-navigation-item-link,d2l-navigation-item-group'
+				);
+				if (this._navItems.length > 0) {
+					setTimeout(function() {
+						this._chomp();
+					}.bind(this), 100); // hackily ensuring DOM is ready to determine row positions
+				}
+			});
 		},
 		_handleMoreGroupFocusedItemHidden: function(event, details) {
 			this._focusItem(details.index);


### PR DESCRIPTION
…IOS and/or faster PCs

So this is the best I could come up with for now.... not very satisfied with it though.

- Right now the first chomp is triggered on a dom update
- This triggers twice, once when the nav is empty, and a second time after the API comes back essentially
- Inside the dom change handler - inside an async block, it queries the dom for nav items and does its chompiness on them
- My theory is that the handlers are firing exceptionally close together and the query is coming back with something not really "ready" the first time through, and then erroring out.  I'm not really sure though. :) 

Two main changes:
- I check for the # of items (in the property) so that hopefully we only try to chomp on the second dom update event (ie when there are actually items present)
- I increased a timeout from 20 to 100.  This might also help.

A word about that timeout:
- It's a really smelly part of the code that I'm not happy or proud of, but I'm yet to come up with a very good alternative given the nature of the problem to solve, that isn't very complicated in code.  But I am thinking about it.
- Even with some extreme throttling in place on my browser, I see absolutely no difference increasing it to 100 from 20.  Even at 300 I couldn't see any flicker effect, actually.

So while I am still thinking about better approaches I think these changes do not make anything worse, and have a pretty good chance of solving the problem for now.