### PR TITLE
Adding background shadow to nav as seen in designs

### DIFF
--- a/navigation.html
+++ b/navigation.html
@@ -8,8 +8,10 @@
 <dom-module id="d2l-navigation">
 	<style>
 		:host {
+			border-bottom: 4px solid #f4f5f6;
 			display: block;
 			min-width: 320px;
+			position: relative;
 		}
 		:host([suppressed]) {
 			display: none;
@@ -19,6 +21,17 @@
 		}
 		:host([loading]) d2l-navigation-resolved {
 			opacity: 0;
+		}
+		.d2l-nav-shadow {
+			background: -moz-linear-gradient(top,  rgba(249,250,251,1) 0%, rgba(249,250,251,0) 100%);
+			background: -webkit-linear-gradient(top,  rgba(249,250,251,1) 0%,rgba(249,250,251,0) 100%);
+			background: linear-gradient(to bottom,  rgba(249,250,251,1) 0%,rgba(249,250,251,0) 100%);
+			bottom: -150px;
+			height: 150px;
+			width: 100%;
+			pointer-events: none;
+			position: absolute;
+			z-index: -95;
 		}
 	</style>
 	<template>
@@ -52,6 +65,7 @@
 			org-unit-name="[[orgUnitName]]"
 			user-href="[[userHref]]"
 			personal-menu-location="[[personalMenuLocation]]"></d2l-navigation-resolved>
+		<div class="d2l-nav-shadow"></div>
 	</template>
 </dom-module>
 <script>

--- a/navigation.html
+++ b/navigation.html
@@ -31,7 +31,7 @@
 			width: 100%;
 			pointer-events: none;
 			position: absolute;
-			z-index: -95;
+			z-index: -100;
 		}
 	</style>
 	<template>


### PR DESCRIPTION
Couple notes:

- Added the new div here rather than say navigation-resolved, so that it shows up faster in the LE.
- I saw some bg elements in the LE with a z-index of 100, so -95 for this seemed about right to me.  Seems to be working well on the pages I have tested so far.
- The "pointer-events" CSS rule is just some fall-back insurance, just in case the somehow covers up something it shouldn't (shouldn't happen though!).

Can't think of anything else.  Pretty simple change though there were a few iterations to decide on creating a border on the existing nav component, and a new shadow div inside it.  There will be a few pages in the LE that need some changes (mostly removing white backgrounds that are set).