### PR TITLE
fix navigation shifting page after it loads

### DIFF
--- a/navigation-main.html
+++ b/navigation-main.html
@@ -12,7 +12,7 @@
 			display: none;
 			height: calc(1rem + 40px);
 		}
-		:host([has-items]) {
+		:host([has-items]), :host-context([loading]) {
 			display: block;
 		}
 		:host([justify-content]) .d2l-navigation-main-wrapper {
@@ -31,7 +31,7 @@
 			flex-wrap: nowrap;
 		}
 		@media(max-width: 992px) {
-			:host, :host([has-items]) {
+			:host, :host([has-items]), :host-context([loading]) {
 				display: none;
 			}
 		}


### PR DESCRIPTION
@capajon interested in your feedback. I've noticed now that we're not waiting for nav to fade the page in that it partially loads with a height of `90px`, then after the links render the height grows to accommodate them -- which shifts the page in an ugly way.

The one case this will look kind of bad is if there ends up being no links. The nav will initially be higher than it needs to be, and then will shrink. Since that's going to be the rare case, I'm OK moving the ugliness to that case instead of the typical one.