### PR TITLE
Us77969 sync enrollments

### DIFF
--- a/course-menu.html
+++ b/course-menu.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-id.html">
-<link rel="import" href="../d2l-polymer-behaviors/d2l-pubsub.html">
+<link rel="import" href="../d2l-polymer-behaviors/d2l-publish-subscribe.html">
 <link rel="import" href="find-page-object-behavior.html">
 <link rel="import" href="graft-behavior.html">
 
@@ -22,8 +22,7 @@
 		_placeholderId: null,
 
 		listeners: {
-			'partial-render': '_onPartialRender',
-			'course-pinned': '_onCoursePinned'
+			'partial-render': '_onPartialRender'
 		},
 
 		behaviors: [
@@ -42,7 +41,7 @@
 				return;
 			}
 
-			if(!this._placeholderId) {
+			if (!this._placeholderId) {
 				this._placeholderId = D2L.Id.getUniqueId();
 
 				this.$$('.d2l-navigation-course-menu-container')

--- a/course-menu.html
+++ b/course-menu.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-id.html">
+<link rel="import" href="../d2l-polymer-behaviors/d2l-pubsub.html">
 <link rel="import" href="find-page-object-behavior.html">
 <link rel="import" href="graft-behavior.html">
 
@@ -11,15 +12,18 @@
 				line-height: 1.5rem;
 			}
 		</style>
-		<div class="d2l-navigation-course-menu-container"></div>
+		<div class="d2l-navigation-course-menu-container d2l-placeholder-inner"></div>
 	</template>
 </dom-module>
 <script>
 	Polymer({
 		is: 'd2l-navigation-course-menu',
 
+		_placeholderId: null,
+
 		listeners: {
-			'partial-render': '_onPartialRender'
+			'partial-render': '_onPartialRender',
+			'course-pinned': '_onCoursePinned'
 		},
 
 		behaviors: [
@@ -28,21 +32,24 @@
 		],
 
 		properties: {
-			loaded: Boolean
+			loaded: Boolean,
+			isDirty: Boolean
 		},
 
-		load: function() {
+		load: function(isDirty) {
 
-			if (this.loaded) {
+			if (!isDirty && this.loaded) {
 				return;
 			}
 
-			var placeholderId = D2L.Id.getUniqueId();
+			if(!this._placeholderId) {
+				this._placeholderId = D2L.Id.getUniqueId();
 
-			this.$$('.d2l-navigation-course-menu-container')
-				.setAttribute('id', placeholderId);
+				this.$$('.d2l-navigation-course-menu-container')
+					.setAttribute('id', this._placeholderId);
+			}
 
-			this.graft(placeholderId);
+			this.graft(this._placeholderId, isDirty);
 
 		},
 

--- a/graft-behavior.html
+++ b/graft-behavior.html
@@ -13,9 +13,9 @@
 				value: false
 			}
 		},
-		graft: function(id) {
+		graft: function(id, forceGraft) {
 
-			if (this._partialled) {
+			if (!forceGraft && this._partialled) {
 				return;
 			}
 			this._partialled = true;

--- a/header/course-menu.html
+++ b/header/course-menu.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
+<link rel="import" href="../../d2l-polymer-behaviors/d2l-publish-subscribe.html">
 <link rel="import" href="../button-highlight-icon.html">
 <link rel="import" href="../course-menu.html">
 <link rel="import" href="../divider.html">
@@ -57,6 +58,10 @@
 		_menu: null,
 		_isDirty: false,
 
+		ready: function() {
+			this._onEnrollmentMessage = this._onEnrollmentMessage.bind(this);
+		},
+
 		attached: function() {
 			this._opener = this.$$('[is="d2l-navigation-button-highlight-icon"]');
 			this.listen(this._opener, 'click', '_onClick');
@@ -69,8 +74,7 @@
 
 			this._menu = this.$$('d2l-navigation-course-menu');
 
-			D2L.PubSub.subscribe('d2l.enrollments.pinned', this._onEnrollmentMessage.bind(this));
-			D2L.PubSub.subscribe('d2l.enrollments.unpinned', this._onEnrollmentMessage.bind(this));
+			D2L.PublishSubscribe.subscribe('d2l.enrollments.pinned', this._onEnrollmentMessage);
 		},
 
 		detached: function() {
@@ -103,22 +107,43 @@
 
 				this._menu.addEventListener('d2l-navigation-course-menu-loaded', onLoad);
 				this._menu.load(this._isDirty);
+
 			}
 
 		},
 
 		_onCourseSelectorItemPinned: function(e) {
-			console.log('Menu item pinned! Course ' + e.detail.orgId );
-			D2L.PubSub.publish('d2l.enrollments.pinned', e.detail.orgId);
+
+			D2L.PublishSubscribe.publish(
+				'd2l.enrollments.pinned', {
+					sender: this,
+					eventName: 'course-pinned',
+					detail: {
+						orgUnitId: e.detail.orgUnitId
+					}
+				});
+
 		},
 
 		_onCourseSelectorItemUnpinned: function(e) {
-			console.log('Menu item unpinned! Course ' + e.detail.orgId );
-			D2L.PubSub.publish('d2l.enrollments.unpinned', e.detail.orgId);
+
+			D2L.PublishSubscribe.publish(
+				'd2l.enrollments.pinned', {
+					sender: this,
+					eventName: 'course-unpinned',
+					detail: {
+						orgUnitId: e.detail.orgUnitId
+					}
+				});
+
 		},
 
 		_onEnrollmentMessage: function(message) {
-			this._isDirty = true;
+
+			if (message.sender !== this) {
+				this._isDirty = true;
+			}
+
 		}
 
 	});

--- a/header/course-menu.html
+++ b/header/course-menu.html
@@ -55,6 +55,7 @@
 		_dropdown: null,
 		_opener: null,
 		_menu: null,
+		_isDirty: false,
 
 		attached: function() {
 			this._opener = this.$$('[is="d2l-navigation-button-highlight-icon"]');
@@ -63,8 +64,13 @@
 			this._dropdown = this.$$('d2l-dropdown');
 			this.listen(this._dropdown, 'd2l-dropdown-open', '_onOpen');
 			this.listen(this._dropdown, 'd2l-dropdown-close', '_onClose');
+			this.listen(this._dropdown, 'd2l-course-selector-item-pinned', '_onCourseSelectorItemPinned');
+			this.listen(this._dropdown, 'd2l-course-selector-item-unpinned', '_onCourseSelectorItemUnpinned');
 
 			this._menu = this.$$('d2l-navigation-course-menu');
+
+			D2L.PubSub.subscribe('d2l.enrollments.pinned', this._onEnrollmentMessage.bind(this));
+			D2L.PubSub.subscribe('d2l.enrollments.unpinned', this._onEnrollmentMessage.bind(this));
 		},
 
 		detached: function() {
@@ -83,21 +89,36 @@
 
 		_onClick: function() {
 
-			if (this._menu.loaded) {
+			if (!this._isDirty && this._menu.loaded) {
 
 				this._dropdown.toggleOpen();
 
 			} else {
 
 				var onLoad = function() {
+					this._isDirty = false;
 					this._menu.removeEventListener('d2l-navigation-course-menu-loaded', onLoad);
 					this._dropdown.toggleOpen();
 				}.bind(this);
 
 				this._menu.addEventListener('d2l-navigation-course-menu-loaded', onLoad);
-				this._menu.load();
+				this._menu.load(this._isDirty);
 			}
 
+		},
+
+		_onCourseSelectorItemPinned: function(e) {
+			console.log('Menu item pinned! Course ' + e.detail.orgId );
+			D2L.PubSub.publish('d2l.enrollments.pinned', e.detail.orgId);
+		},
+
+		_onCourseSelectorItemUnpinned: function(e) {
+			console.log('Menu item unpinned! Course ' + e.detail.orgId );
+			D2L.PubSub.publish('d2l.enrollments.unpinned', e.detail.orgId);
+		},
+
+		_onEnrollmentMessage: function(message) {
+			this._isDirty = true;
 		}
 
 	});

--- a/test/header/course-menu.html
+++ b/test/header/course-menu.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>course tests</title>
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../../header/course-menu.html">
+	</head>
+	<body>
+
+		<test-fixture id="typical">
+			<template>
+				<d2l-navigation-header-course-menu
+					org-unit-name="course name"
+					org-unit-home="/org/unit/home"></d2l-navigation-header-course-menu>
+			</template>
+		</test-fixture>
+
+		<script>
+			var courseMenu;
+
+			describe('course synchronization', function() {
+
+				beforeEach(function() {
+					D2L.PublishSubscribe.clearSubscriptions('d2l.enrollments.pinned');
+					courseMenu = fixture('typical');
+				});
+
+				it('should publish a course enrollment pin message when a pin/unpin event is received', function(done) {
+
+					var expectedPinMessage = {
+						sender: courseMenu,
+						eventName: 'course-pinned',
+						detail: {
+							orgUnitId: 12345
+						}
+					};
+
+					var pinMessageHandler = function(message) {
+						expect(message).to.deep.equal(expectedPinMessage);
+						done();
+					};
+
+					var courseSelectorPinEvent = new CustomEvent('d2l-course-selector-item-pinned', {
+						detail: {
+							orgUnitId: 12345
+						}
+					});
+
+					D2L.PublishSubscribe.subscribe('d2l.enrollments.pinned', pinMessageHandler);
+
+					courseMenu._dropdown.dispatchEvent(courseSelectorPinEvent);
+
+				});
+
+				it('should reload the course menu on next open if menu previously loaded and pin/unpin message received', function() {
+
+					var clock = sinon.useFakeTimers();
+					courseMenu._menu.load = sinon.stub();
+
+					expect(courseMenu._isDirty)
+						.to.be.false;
+
+					courseMenu._menu.loaded = true;
+
+					D2L.PublishSubscribe.publish(
+						'd2l.enrollments.pinned', {
+							sender: null,
+							eventName: 'course-pinned',
+							detail: {
+								orgUnitId: 12345
+							}
+						});
+
+					clock.tick(10);
+
+					courseMenu._onClick(); // Calling directly rather than using .click() to avoid auto-close logic
+
+					expect(courseMenu._menu.load.calledWith(true))
+						.to.be.true;
+
+				});
+
+			});
+
+		</script>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,9 @@
 				'header/course.html',
 				'header/course.html?dom=shadow',
 				'header/personal-menu.html',
-				'header/personal-menu.html?dom=shadow'
+				'header/personal-menu.html?dom=shadow',
+				'header/course-menu.html',
+				'header/course-menu.html?dom=shadow'
 			]);
 		</script>
 	</body>


### PR DESCRIPTION
Note: Will likely drop this in favour of Dave L's suggesting to just have the course selector update itself rather than have nav reload the view.

Allows the course menu to be reloaded on receiving an external message of a pin/unpin action (eg. from the My Courses widget), and publishes course pin/unpin messages on receiving relevant events from the course selector view, allowing synchronization with other components. Reloading of the course menu partial view is delayed until the next time the dropdown is opened.