### PR TITLE
Update to latest d2l-page-load-progress.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "d2l-icons": "^2.15.2",
     "d2l-menu": "^0.2.6",
     "d2l-offscreen": "^2.2.1",
-    "d2l-page-load-progress": "^1.2.1",
+    "d2l-page-load-progress": "^1.2.2",
     "d2l-performance": "^0.0.3",
     "d2l-polymer-behaviors": "^0.0.4",
     "polymer": "^1.7.0",


### PR DESCRIPTION
Fixes finish being called before start (which was resulting in progress bar from never finishing).